### PR TITLE
Add ability to disable buttons

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -9,7 +9,9 @@ const MAX_HEIGHT = Dimensions.get('window').height * 0.7
 class ActionSheet extends React.Component {
   static defaultProps = {
     tintColor: '#007AFF',
+    disabledColor: '#A0A0A0',
     buttonUnderlayColor: '#F4F4F4',
+    disabledIndexes: [],
     onPress: () => {},
     styles: {}
   }
@@ -151,9 +153,13 @@ class ActionSheet extends React.Component {
 
   _createButton (title, index) {
     const styles = this.styles
-    const { buttonUnderlayColor, cancelButtonIndex, destructiveButtonIndex, tintColor } = this.props
-    const fontColor = destructiveButtonIndex === index ? WARN_COLOR : tintColor
+    const { buttonUnderlayColor, cancelButtonIndex, destructiveButtonIndex, disabledIndexes, tintColor, disabledColor } = this.props
+    let fontColor = destructiveButtonIndex === index ? WARN_COLOR : tintColor
     const buttonBoxStyle = cancelButtonIndex === index ? styles.cancelButtonBox : styles.buttonBox
+    const isDisabled = disabledIndexes.indexOf(index) !== -1
+    if (isDisabled) {
+      fontColor = disabledColor
+    }
     return (
       <TouchableHighlight
         key={index}
@@ -161,6 +167,7 @@ class ActionSheet extends React.Component {
         underlayColor={buttonUnderlayColor}
         style={buttonBoxStyle}
         onPress={() => this.hide(index)}
+        disabled={isDisabled}
       >
         {React.isValidElement(title) ? title : (
           <Text style={[styles.buttonText, {color: fontColor}]}>{title}</Text>


### PR DESCRIPTION
Adds ability to disable buttons, however, you cannot pass in a `<Component` to the `options` array. Because the style will not carry down into the child component. Something to think about in the future.